### PR TITLE
20 リモートのエピソードを作成する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ allow-direct-references = true
 
 [tool.ruff]
 line-length = 120
+[tool.ruff.lint]
 select = ["F", "E", "W", "D"]
 ignore = [
   "D400", # docstring first line must end with period

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kakuyomu-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "Kakuyomu CLI"
 authors = [{ name = "kokardy", email = "mgc1028@gmail.com" }]
 dependencies = [

--- a/src/kakuyomu/cli/commands/episode.py
+++ b/src/kakuyomu/cli/commands/episode.py
@@ -32,6 +32,7 @@ def link(filepath: str) -> None:
     except Exception as e:
         print(f"リンクに失敗しました: {e}")
 
+
 @episode.command()
 def unlink() -> None:
     """Unlink episodes"""
@@ -43,10 +44,12 @@ def unlink() -> None:
 
 
 @episode.command()
-def create() -> None:
+@click.argument("title")
+@click.argument("file_path")
+def create(title: str, file_path: str) -> None:
     """Create episode"""
-    # client.create_episode()
-    print("not implemented yet")
+    client.create_remote_episode(title=title, file_path=file_path)
+    print(f"エピソードを作成しました: {title}")
 
 
 @episode.command()

--- a/src/kakuyomu/client/decorators.py
+++ b/src/kakuyomu/client/decorators.py
@@ -1,7 +1,6 @@
 """Decorators for the client"""
 from typing import Callable, Concatenate, Self
 
-
 from kakuyomu.types.errors import NotLoginError, WorkNotSetError
 
 

--- a/src/kakuyomu/client/request_models.py
+++ b/src/kakuyomu/client/request_models.py
@@ -1,0 +1,18 @@
+"""Request body models for POST or PUT"""
+from pydantic import BaseModel
+
+
+class WithCsrfToken(BaseModel):
+    """Request with CSRF token"""
+
+    csrf_token: str
+
+
+class CreateEpisodeRequest(BaseModel):
+    """Create episode request form"""
+
+    title: str
+    status: str = "draft"
+    edit_reservation: int = 0
+    keep_editing: int = 0
+    body: str

--- a/src/kakuyomu/client/toc.py
+++ b/src/kakuyomu/client/toc.py
@@ -1,0 +1,42 @@
+"""Table of contents action"""
+from typing import Iterable
+
+from pydantic import BaseModel
+
+from kakuyomu.types import EpisodeId
+
+type CSRFToken = str  # type: ignore
+
+
+class DeleteRequestForm(BaseModel):
+    """Delete request form"""
+
+    csrf_token: CSRFToken
+    bulk_action_name: str
+    target_toc_item_id: list[str]
+
+
+class TOCAction:
+    """Table of contents action"""
+
+    @staticmethod
+    def delete(csrf_token: CSRFToken, episodes: Iterable[EpisodeId]) -> DeleteRequestForm:
+        """
+        Delete episodes
+
+        Returns
+        -------
+        JsonDict
+        csrf_token: xxxxxxxxxxxxxxxxxxxx
+        bulk_action_name: delete
+        target_toc_item_id: episode:00000000000000000001
+        target_toc_item_id: episode:00000000000000000002
+
+        """
+        target_toc_item_id = [f"episode:{episode}" for episode in episodes]
+        result = DeleteRequestForm(
+            csrf_token=csrf_token,
+            bulk_action_name="delete",
+            target_toc_item_id=target_toc_item_id,
+        )
+        return result

--- a/src/kakuyomu/scrapers/work_page.py
+++ b/src/kakuyomu/scrapers/work_page.py
@@ -13,11 +13,11 @@ class WorkPageScraper:
     def __init__(self, html: str):
         """Initialize WorkPageScraper"""
         self.html = html
+        self.soup = bs4.BeautifulSoup(html, "html.parser")
 
     def scrape_episodes(self) -> list[RemoteEpisode]:
         """Scrape episodes from work page"""
-        soup = bs4.BeautifulSoup(self.html, "html.parser")
-        links = soup.select("td.episode-title a")
+        links = self.soup.select("td.episode-title a")
         result: list[RemoteEpisode] = []
         for link in links:
             href = link.get("href")
@@ -28,3 +28,13 @@ class WorkPageScraper:
             episode = RemoteEpisode(id=episode_id, title=episode_title)
             result.append(episode)
         return result
+
+    def scrape_csrf_token(self) -> str:
+        """Scrape csrf token from work page"""
+        tag = self.soup.select_one("input[name=csrf_token]")
+        if not tag:
+            raise ValueError("csrf_token not found")
+        csrf_token = tag.get("value")
+        if not isinstance(csrf_token, str):
+            raise ValueError("csrf_token is not str")
+        return csrf_token

--- a/src/kakuyomu/settings/const.py
+++ b/src/kakuyomu/settings/const.py
@@ -32,8 +32,10 @@ class URL(metaclass=ConstMeta):
     ROOT: Final[str] = "https://kakuyomu.jp"
     LOGIN: Final[str] = f"{ROOT}/login"
     MY: Final[str] = f"{ROOT}/my"
-    MY_WORK: Final[str] = f"{MY}/works/" + "{work_id}"
+    MY_WORK: Final[str] = f"{MY}/works/{{work_id}}"
     ANNTENA_WORKS: Final[str] = f"{ROOT}/anntena/works"
+    NEW_EPISODE: Final[str] = f"{MY_WORK}/episodes/new"
+    EDIT_TOC: Final[str] = f"{MY_WORK}/edit_toc_bulk"
 
 
 class Login(metaclass=ConstMeta):

--- a/src/kakuyomu/types/__init__.py
+++ b/src/kakuyomu/types/__init__.py
@@ -3,10 +3,10 @@
 from .work import EpisodeId, LocalEpisode, LoginStatus, RemoteEpisode, Work, WorkId
 
 __all__ = [
-    "Work",
-    "WorkId",
-    "LocalEpisode",
     "EpisodeId",
+    "LocalEpisode",
     "LoginStatus",
     "RemoteEpisode",
+    "Work",
+    "WorkId",
 ]

--- a/src/kakuyomu/types/errors.py
+++ b/src/kakuyomu/types/errors.py
@@ -23,3 +23,9 @@ class EpisodeNotFoundError(Exception):
 
 class EpisodeHasNoPathError(Exception):
     """Episode has no path error"""
+
+class CreateEpisodeFailedError(Exception):
+    """Create episode error"""
+
+class DeleteEpisodeFailedError(Exception):
+    """Episode delete error"""

--- a/src/kakuyomu/types/work.py
+++ b/src/kakuyomu/types/work.py
@@ -1,11 +1,11 @@
 """Define type aliases and models."""
 
-from typing import Optional, TypeAlias
+from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
-WorkId: TypeAlias = str
-EpisodeId: TypeAlias = str
+type WorkId = str  # type: ignore
+type EpisodeId = str  # type: ignore
 
 
 class Episode(BaseModel):
@@ -26,7 +26,7 @@ class Episode(BaseModel):
 class RemoteEpisode(Episode):
     """Remote episode model"""
 
-    pass
+    model_config = ConfigDict(frozen=True)
 
 
 class LocalEpisode(Episode):

--- a/tests/general/test_login.py
+++ b/tests/general/test_login.py
@@ -1,8 +1,13 @@
 """Test for login"""
-from kakuyomu.client import Client
-from kakuyomu.types import LocalEpisode, Work
+import os
+from typing import Callable
 
-from ..helper import Test
+from kakuyomu.client import Client
+from kakuyomu.types import LocalEpisode, RemoteEpisode, Work
+
+from ..helper import EpisodeExistsTest
+
+here = os.path.abspath(os.path.dirname(__file__))
 
 work = Work(
     id="16816927859498193192",
@@ -13,14 +18,39 @@ episode = LocalEpisode(
     title="第4話",
 )
 
+episodes = [
+    RemoteEpisode(id="16816927859859822600", title="第1話"),
+    RemoteEpisode(id="16816927859880032697", title="第4話"),
+    RemoteEpisode(id="16816927859880026113", title="第2話"),
+    RemoteEpisode(id="16816927859880029939", title="第3話"),
+    RemoteEpisode(id="16816927860079743550", title="第4話"),
+    RemoteEpisode(id="16816927860079843351", title="第5話"),
+    RemoteEpisode(id="16816927860079889260", title="第6話"),
+    RemoteEpisode(id="16816927860079921252", title="第7話"),
+    RemoteEpisode(id="16816927860265371490", title="第8話"),
+]
 
-class TestLogin(Test):
+
+class TestConnectToKakuyomu(EpisodeExistsTest):
     """
-    Test for login
+    kakuyomu.jpとの疎通を伴うテスト
 
     疎通確認のためのテスト
     kakuyomuとの通信をmockにしない
     """
+
+    def setup_method(self, method: Callable[..., None]) -> None:
+        """Create work and episode"""
+        super().setup_method(method)
+        if not self.client.status().is_login:
+            self.client.login()
+
+    def teardown_method(self, method: Callable[..., None]) -> None:
+        """Remove all created episodes"""
+        super().teardown_method(method)
+        current_episodes = self.client.get_episodes()
+        delete_ids = [_episode.id for _episode in current_episodes if _episode.id not in {e.id for e in episodes}]
+        self.client.delete_remote_episodes(episodes=[delete_ids])
 
     def test_status_not_login(self, logout_client: Client) -> None:
         """Test status not login"""
@@ -33,16 +63,42 @@ class TestLogin(Test):
         status = login_client.status()
         assert status.is_login
 
-    def test_work_list(self, client: Client) -> None:
+    def test_work_list(self) -> None:
         """Work list test"""
-        works = client.get_works()
+        works = self.client.get_works()
         assert work.id in works
         assert works[work.id].title == work.title
 
-    def test_episode_list(self, client: Client) -> None:
+    def test_episode_list(self) -> None:
         """Episode list test"""
-        episodes = client.get_episodes()
+        episodes = self.client.get_episodes()
         assert episode.id in {episodes.id for episodes in episodes}
         index = [episode.id for episode in episodes].index(episode.id)
         assert index > -1
         assert episodes[index].title == episode.title
+
+    def test_create_and_delete_episode(self) -> None:
+        """
+        Create episode test
+
+        エピソードが増えることを確認する
+        エピソードが増えたら削除する
+        """
+        client = self.client
+        # before
+        before_episodes = client.get_episodes()
+        client.create_remote_episode(title="テスト001", file_path=os.path.join(self.client.work_dir, "publish/001.txt"))
+        # after
+        after_episodes = client.get_episodes()
+
+        diff = set(after_episodes) - set(before_episodes)
+        assert len(diff) == 1
+        new_episode = diff.pop()
+
+        client.delete_remote_episodes(episodes=[new_episode.id])
+
+        final_episodes = client.get_episodes()
+        assert len(before_episodes) == len(final_episodes)
+
+        # check linked episode
+        assert new_episode.id in {episode.id for episode in client.work.episodes}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 特定のタイトルとファイルパスでエピソードを作成する機能を追加しました。
	- POSTまたはPUTリクエスト用のリクエストボディモデルを導入しました。これには、タイトル、ステータス、編集予約、編集継続、本文のフィールドを含むエピソード作成リクエストの処理が含まれます。
	- 目次アクションを処理する機能を導入しました。これには、CSRFトークンとエピソードIDを使用してエピソードを削除するための削除リクエストフォームを生成する`delete`メソッドを含む`TOCAction`クラスが含まれます。
	- エピソードの作成と削除の機能を追加しました。

- **バグ修正**
	- 不必要なインポート文を削除しました。

- **リファクタ**
	- ヘッダーの扱いをより堅牢にするために`_post`メソッドを修正しました。
	- エピソードリンク処理を扱う`_link_file`メソッドを修正しました。
	- `WorkPageScraper`クラスの`scrape_episodes`メソッドが`soup`属性を直接使用するように変更し、作業ページからCSRFトークンを抽出する新しいメソッド`scrape_csrf_token`を追加しました。

- **テスト**
	- エピソードの作成と削除をテストする新しいメソッドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->