### PR TITLE
impl kakuyomu episode show

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kakuyomu-cli"
-version = "0.7.0"
+version = "0.8.0"
 description = "Kakuyomu CLI"
 authors = [{ name = "kokardy", email = "mgc1028@gmail.com" }]
 dependencies = [

--- a/src/kakuyomu/cli/commands/episode.py
+++ b/src/kakuyomu/cli/commands/episode.py
@@ -53,6 +53,40 @@ def create(title: str, file_path: str) -> None:
 
 
 @episode.command()
+@click.option("--line", "-l", type=int, default=3)
+def show(line: int) -> None:
+    """
+    Show episode contents
+
+    Args:
+    ----
+        line (int): 表示する行数
+
+    """
+    body = client.get_remote_episode_body()
+    count = 0
+    for row in body:
+        if count >= line:
+            break
+        try:
+            # 空白行はスキップ
+            if row.strip() == "":
+                continue
+            print(row)
+            count += 1
+        except StopIteration:
+            return
+        except Exception as e:
+            raise e
+
+
+@episode.command()
+def update() -> None:
+    """Update episode"""
+    print("not implemented yet")
+
+
+@episode.command()
 def publish() -> None:
     """Publish episode"""
     # client.publish_episode()

--- a/src/kakuyomu/cli/commands/episode.py
+++ b/src/kakuyomu/cli/commands/episode.py
@@ -77,7 +77,7 @@ def show(line: int) -> None:
         except StopIteration:
             return
         except Exception as e:
-            raise e
+            print(f"予期しないエラー: {e}")
 
 
 @episode.command()

--- a/src/kakuyomu/scrapers/episode_page.py
+++ b/src/kakuyomu/scrapers/episode_page.py
@@ -1,0 +1,25 @@
+"""Module for scraping episode page."""
+import bs4
+
+from kakuyomu.types.errors import EpisodeBodyNotFoundError
+
+
+class EpisodePageScraper:
+    """Class for scrape my page."""
+
+    html: str
+
+    def __init__(self, html: str):
+        """Initialize"""
+        self.html = html
+
+    def scrape_body(self) -> str:
+        """Scrape works from episode page"""
+        soup = bs4.BeautifulSoup(self.html, "html.parser")
+        textarea = soup.select_one("textarea[name='body']")
+        if not textarea:
+            raise EpisodeBodyNotFoundError(f"Tag<id=episodeBody-input> not found: {textarea=}")
+        if not isinstance(textarea, bs4.Tag):
+            raise EpisodeBodyNotFoundError(f"<id=episodeBody-input> is not Tag: {textarea=}")
+        body = textarea.text
+        return body

--- a/src/kakuyomu/scrapers/episode_page.py
+++ b/src/kakuyomu/scrapers/episode_page.py
@@ -18,8 +18,8 @@ class EpisodePageScraper:
         soup = bs4.BeautifulSoup(self.html, "html.parser")
         textarea = soup.select_one("textarea[name='body']")
         if not textarea:
-            raise EpisodeBodyNotFoundError(f"Tag<id=episodeBody-input> not found: {textarea=}")
+            raise EpisodeBodyNotFoundError(f"Textarea<name=body> not found: {textarea=}")
         if not isinstance(textarea, bs4.Tag):
-            raise EpisodeBodyNotFoundError(f"<id=episodeBody-input> is not Tag: {textarea=}")
+            raise EpisodeBodyNotFoundError(f"Textarea<name=body> is not Tag: {textarea=}")
         body = textarea.text
         return body

--- a/src/kakuyomu/settings/const.py
+++ b/src/kakuyomu/settings/const.py
@@ -36,6 +36,7 @@ class URL(metaclass=ConstMeta):
     ANNTENA_WORKS: Final[str] = f"{ROOT}/anntena/works"
     NEW_EPISODE: Final[str] = f"{MY_WORK}/episodes/new"
     EDIT_TOC: Final[str] = f"{MY_WORK}/edit_toc_bulk"
+    EPISODE: Final[str] = f"{MY_WORK}/episodes/{{episode_id}}"
 
 
 class Login(metaclass=ConstMeta):

--- a/src/kakuyomu/types/errors.py
+++ b/src/kakuyomu/types/errors.py
@@ -24,8 +24,14 @@ class EpisodeNotFoundError(Exception):
 class EpisodeHasNoPathError(Exception):
     """Episode has no path error"""
 
+
 class CreateEpisodeFailedError(Exception):
     """Create episode error"""
 
+
 class DeleteEpisodeFailedError(Exception):
     """Episode delete error"""
+
+
+class EpisodeBodyNotFoundError(Exception):
+    """Episode body not found error"""

--- a/tests/general/test_login.py
+++ b/tests/general/test_login.py
@@ -102,3 +102,13 @@ class TestConnectToKakuyomu(EpisodeExistsTest):
 
         # check linked episode
         assert new_episode.id in {episode.id for episode in client.work.episodes}
+
+    def test_get_remote_episode_body(self) -> None:
+        """
+        Get remote episode body test
+
+        取得されたエピソードの内容を検証する
+        """
+        body_rows = self.client._get_remote_episode_body(episode.id)
+        body = "\n".join(body_rows)
+        assert body.strip() == "test"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - エピソードCLIコマンドグループに`show`と`update`の2つの新しいコマンドを追加しました。`show`コマンドは、リモートから取得したエピソードの内容を指定された行数表示します。`update`コマンドはまだ実装されていません。
    - エピソードページのスクレイピングモジュールを新規追加しました。このモジュールは、HTMLからエピソードページの本文を抽出する`EpisodePageScraper`クラスを含んでいます。

- **機能改善**
    - エピソードの本文をリモートから取得する新しいメソッドを追加しました。

- **バグ修正**
    - 特定のエピソードにアクセスするためのURLテンプレートを表す新しい定数`EPISODE`を追加しました。

- **テスト**
    - リモートからのエピソード本文取得機能を検証する新しいテストメソッドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->