### PR TITLE
35 リモートエピソードをworktomlに反映

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,6 @@ extraPaths = ["src", ".venv/lib/python3.12/site-packages"]
 pythonVersion = "3.12"
 
 [tool.rye.scripts]
-test = "pytest -s"
+test = "pytest -vv -s -x"
 typecheck = "mypy --strict ."
 lint = "ruff check ."

--- a/src/kakuyomu/cli/commands/episode.py
+++ b/src/kakuyomu/cli/commands/episode.py
@@ -20,6 +20,13 @@ def ls() -> None:
         print(i, episode)
 
 
+@episode.command
+def fetch() -> None:
+    """Fetch remote episodes to work.toml"""
+    diff = client.fetch_remote_episodes()
+    print(diff)
+
+
 @episode.command()
 @click.argument("filepath")
 def link(file: str) -> None:

--- a/src/kakuyomu/client/web.py
+++ b/src/kakuyomu/client/web.py
@@ -15,7 +15,8 @@ from kakuyomu.scrapers.episode_page import EpisodePageScraper
 from kakuyomu.scrapers.my_page import MyPageScraper
 from kakuyomu.scrapers.work_page import WorkPageScraper
 from kakuyomu.settings import CONFIG_DIRNAME, URL, Login
-from kakuyomu.types import EpisodeId, LocalEpisode, LoginStatus, RemoteEpisode, Work, WorkId
+from kakuyomu.types import Diff, EpisodeId, LocalEpisode, LoginStatus, RemoteEpisode, Work, WorkId
+from kakuyomu.types.episode_query import Query
 from kakuyomu.types.errors import (
     CreateEpisodeFailedError,
     DeleteEpisodeFailedError,
@@ -131,6 +132,32 @@ class Client:
         csrf_token = scraper.scrape_csrf_token()
         self._toc_token = csrf_token
         return episodes
+
+    def fetch_remote_episodes(self) -> Diff:
+        """Fetch remote episodes"""
+        raise Exception("aaa")
+        before_episodes = self.work.episodes
+        print(f"{ before_episodes= }")
+
+        raise Exception("aaa")
+
+        episodes = []
+
+        for remote_episode in self.get_remote_episodes():
+            local_episode = self.get_local_episode_by_remote_episode(remote_episode)
+            episodes.append(local_episode)
+
+        print(f"{ episodes= }")
+
+        self.work.episodes = episodes
+        after_episodes = self.work.episodes
+
+        self._dump_work_toml(self.work)
+
+        before = Query(before_episodes)
+        after = Query(after_episodes)
+
+        return before.diff(after)
 
     def link_file(self, filepath: Path) -> LocalEpisode:
         """Link file"""

--- a/src/kakuyomu/client/web.py
+++ b/src/kakuyomu/client/web.py
@@ -4,7 +4,8 @@ Web client for kakuyomu
 This module is a web client for kakuyomu.jp.
 """
 import pickle
-from typing import Iterable
+import time
+from typing import Iterable, Sequence
 
 import requests
 import toml
@@ -42,10 +43,11 @@ class Client:
     cwd: Path
     config_dir: ConfigDir
 
-    def __init__(self, cwd: Path = Path.cwd()) -> None:
+    def __init__(self, cwd: Path = Path.cwd(), wait_time: float = 0.1) -> None:
         """Initialize web client"""
         self.session = requests.Session()
         self.cwd = cwd
+        self.wait_time = wait_time
         try:
             self.config_dir = self.cwd.config_dir
         except FileNotFoundError as e:
@@ -72,9 +74,11 @@ class Client:
         return Work.load(self.config_dir.work_toml)
 
     def _get(self, url: str, **kwargs) -> requests.Response:  # type: ignore
+        time.sleep(self.wait_time)
         return self.session.get(url, **kwargs)
 
     def _post(self, url: str, **kwargs) -> requests.Response:  # type: ignore
+        time.sleep(self.wait_time)
         if "headers" in kwargs:
             kwargs["headers"]["X-requested-With"] = "XMLHttpRequest"
         else:
@@ -122,7 +126,8 @@ class Client:
         works = MyPageScraper(html).scrape_works()
         return works
 
-    def get_remote_episodes(self) -> list[RemoteEpisode]:
+    @require_login
+    def get_remote_episodes(self) -> Sequence[RemoteEpisode]:
         """Get episodes and csrf token from work page"""
         work_id = self.work.id
         res = self._get(URL.MY_WORK.format(work_id=work_id))
@@ -133,13 +138,10 @@ class Client:
         self._toc_token = csrf_token
         return episodes
 
+    @require_login
     def fetch_remote_episodes(self) -> Diff:
         """Fetch remote episodes"""
-        raise Exception("aaa")
         before_episodes = self.work.episodes
-        print(f"{ before_episodes= }")
-
-        raise Exception("aaa")
 
         episodes = []
 
@@ -147,18 +149,19 @@ class Client:
             local_episode = self.get_local_episode_by_remote_episode(remote_episode)
             episodes.append(local_episode)
 
-        print(f"{ episodes= }")
+        work = self.work
+        work.episodes = episodes
 
-        self.work.episodes = episodes
-        after_episodes = self.work.episodes
+        after_episodes = work.episodes
 
-        self._dump_work_toml(self.work)
+        self._dump_work_toml(work)
 
         before = Query(before_episodes)
         after = Query(after_episodes)
 
         return before.diff(after)
 
+    @require_login
     def link_file(self, filepath: Path) -> LocalEpisode:
         """Link file"""
         try:
@@ -295,7 +298,13 @@ class Client:
             logger.error(f"{res=}")
             raise DeleteEpisodeFailedError(f"delete failed: {episodes=}")
 
-    # @require_login
+    @require_login
+    def update_remote_episode(self) -> RemoteEpisode:
+        """Update remote episodes"""
+        remote_episode = self._select_remote_episode()
+        self._update_remote_episode(remote_episode.id)
+        return remote_episode
+
     def _update_remote_episode(self, episode_id: EpisodeId, title: str = "", body: Iterable[str] = []) -> None:
         """
         Update remote episode
@@ -333,13 +342,6 @@ class Client:
             raise EpisodeUpdateFailedError(f"update failed: {res}")
 
     @require_login
-    def update_remote_episode(self) -> RemoteEpisode:
-        """Update remote episodes"""
-        remote_episode = self._select_remote_episode()
-        self._update_remote_episode(remote_episode.id)
-        return remote_episode
-
-    @require_login
     def initialize_work(self) -> None:
         """Initialize work"""
         # check if work toml already exists
@@ -361,9 +363,10 @@ class Client:
         except IndexError:
             raise ValueError("選択された番号が存在しません")
 
+    @require_login
     def get_remote_episode(self, episode_id: EpisodeId) -> RemoteEpisode:
         """Get remote episode"""
-        episodes = self.get_remote_episodes()
+        episodes: Sequence[RemoteEpisode] = self.get_remote_episodes()
         for episode in episodes:
             if episode.id == episode_id:
                 return episode
@@ -382,9 +385,6 @@ class Client:
     @require_login
     def get_remote_episode_body(self) -> Iterable[str]:
         """Get episode body"""
-        episodes = self.get_remote_episodes()
-        for i, remote_episode in enumerate(episodes):
-            print(f"{i}: {remote_episode}")
         try:
             remote_episode = self._select_remote_episode()
             body: Iterable[str] = self._get_remote_episode_body(remote_episode.id)
@@ -407,7 +407,7 @@ class Client:
 
     def _select_remote_episode(self) -> RemoteEpisode:
         """Select remote episode"""
-        episodes = self.get_remote_episodes()
+        episodes: Sequence[RemoteEpisode] = self.get_remote_episodes()
         for i, episode in enumerate(episodes):
             print(f"{i}: {episode}")
         try:

--- a/src/kakuyomu/logger.py
+++ b/src/kakuyomu/logger.py
@@ -4,7 +4,7 @@ import logging
 import coloredlogs
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.WARN)
 
 handler = logging.StreamHandler()
 handler.setLevel(logging.DEBUG)

--- a/src/kakuyomu/types/__init__.py
+++ b/src/kakuyomu/types/__init__.py
@@ -1,8 +1,9 @@
 """Define type aliases and models."""
 
-from .work import EpisodeId, LocalEpisode, LoginStatus, RemoteEpisode, Work, WorkId
+from .work import Diff, EpisodeId, LocalEpisode, LoginStatus, RemoteEpisode, Work, WorkId
 
 __all__ = [
+    "Diff",
     "EpisodeId",
     "LocalEpisode",
     "LoginStatus",

--- a/src/kakuyomu/types/episode_query.py
+++ b/src/kakuyomu/types/episode_query.py
@@ -17,7 +17,7 @@ class Query:
         if self._exists_same_id(episodes):
             raise ValueError("Duplicated id")
         self._list = episodes
-        self._dist = {episode.id: episode for episode in episodes}
+        self._dict = {episode.id: episode for episode in episodes}
 
     def _exists_same_id(self, episodes: Sequence[Episode]) -> bool:
         """Validate episodes"""
@@ -34,7 +34,6 @@ class Query:
         removed = set(self._dict.keys()) - set(newer._dict.keys())
 
         updated = set()
-
         remains = set(self._dict.keys()) & set(newer._dict.keys())
 
         for remain in remains:
@@ -46,3 +45,6 @@ class Query:
             updated=[newer._dict[episode_id] for episode_id in updated],
         )
 
+    def __str__(self) -> str:
+        """Return string representation of the query"""
+        return "\n".join([episode.id for episode in self._list])

--- a/src/kakuyomu/types/episode_query.py
+++ b/src/kakuyomu/types/episode_query.py
@@ -1,0 +1,48 @@
+"""Episode query"""
+
+from collections.abc import Sequence
+
+from .work import Diff, Episode, EpisodeId
+
+
+class Query:
+    """Episode query"""
+
+    _dict: dict[EpisodeId, Episode]
+    _list: list[Episode]
+
+    def __init__(self, episodes: Sequence[Episode]) -> None:
+        """Initialize episode query"""
+        episodes = list(episodes)
+        if self._exists_same_id(episodes):
+            raise ValueError("Duplicated id")
+        self._list = episodes
+        self._dist = {episode.id: episode for episode in episodes}
+
+    def _exists_same_id(self, episodes: Sequence[Episode]) -> bool:
+        """Validate episodes"""
+        ids = [episode.id for episode in episodes]
+        return not len(ids) == len(set(ids))
+
+    def get(self, episode_id: EpisodeId) -> Episode:
+        """Get episode by id"""
+        return self._dict[episode_id]
+
+    def diff(self, newer: "Query") -> Diff:
+        """Diff episodes"""
+        appended = set(newer._dict.keys()) - set(self._dict.keys())
+        removed = set(self._dict.keys()) - set(newer._dict.keys())
+
+        updated = set()
+
+        remains = set(self._dict.keys()) & set(newer._dict.keys())
+
+        for remain in remains:
+            if self._dict[remain] != newer._dict[remain]:
+                updated.add(remain)
+        return Diff(
+            appended=[newer._dict[episode_id] for episode_id in appended],
+            removed=[self._dict[episode_id] for episode_id in removed],
+            updated=[newer._dict[episode_id] for episode_id in updated],
+        )
+

--- a/src/kakuyomu/types/work.py
+++ b/src/kakuyomu/types/work.py
@@ -102,3 +102,11 @@ class LoginStatus(BaseModel):
 
     is_login: bool
     email: str
+
+
+class Diff(BaseModel):
+    """Episodes diff model"""
+
+    appended: list[Episode] = []
+    removed: list[Episode] = []
+    updated: list[Episode] = []

--- a/tests/general/test_episode.py
+++ b/tests/general/test_episode.py
@@ -8,7 +8,7 @@ from kakuyomu.types import LocalEpisode
 from kakuyomu.types.errors import EpisodeAlreadyLinkedError, EpisodeHasNoPathError
 from kakuyomu.types.path import Path
 
-from ..helper import EpisodeExistsTest, NoEpisodesTest
+from ..helper import EpisodeExistsTest, NoEpisodeTest
 
 episode_with_path = LocalEpisode(
     id="16816927859880032697",
@@ -22,7 +22,7 @@ episode_without_path = LocalEpisode(
 
 
 @pytest.mark.usefixtures("fake_get_episodes")
-class TestEpisodeNoEpisode(NoEpisodesTest):
+class TestNoEpisode(NoEpisodeTest):
     """Test in the case that no episode test"""
 
     def test_episode_list(self) -> None:
@@ -54,8 +54,10 @@ class TestEpisodeNoEpisode(NoEpisodesTest):
             self.client.link_file(file_path)
 
 
+
+
 @pytest.mark.usefixtures("fake_get_episodes")
-class TestEpisodeEpisodesExist(EpisodeExistsTest):
+class TestEpisodesExist(EpisodeExistsTest):
     """Test in the case that Episode exists test"""
 
     def test_episode_unlink(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/general/test_login.py
+++ b/tests/general/test_login.py
@@ -4,7 +4,7 @@ from typing import Callable
 from kakuyomu.client import Client
 from kakuyomu.types import LocalEpisode, RemoteEpisode, Work
 
-from ..helper import EpisodeExistsTest
+from ..helper import EpisodeExistsTest, NoEpisodeTest
 
 work = Work(
     id="16816927859498193192",
@@ -28,7 +28,7 @@ episodes = [
 ]
 
 
-class TestConnectToKakuyomu(EpisodeExistsTest):
+class TestEpisodesExist(EpisodeExistsTest):
     """
     kakuyomu.jpとの疎通を伴うテスト
 
@@ -147,3 +147,14 @@ class TestConnectToKakuyomu(EpisodeExistsTest):
         remote_episode = self.client.get_remote_episode(episode.id)
         assert new_title == remote_episode.title
         assert new_body == list(self.client._get_remote_episode_body(episode.id))
+
+
+class TestNoEpisode(NoEpisodeTest):
+    """kakuyomuとの疎通を伴うテスト.エピソードなし"""
+
+    def test_fetch(self) -> None:
+        """Fetch test"""
+        episodes = self.client.work.episodes
+        assert episodes
+        fetched = self.client.fetch_remote_episodes()
+        assert fetched

--- a/tests/general/test_login.py
+++ b/tests/general/test_login.py
@@ -154,7 +154,15 @@ class TestNoEpisode(NoEpisodeTest):
 
     def test_fetch(self) -> None:
         """Fetch test"""
-        episodes = self.client.work.episodes
-        assert episodes
-        fetched = self.client.fetch_remote_episodes()
-        assert fetched
+        before_episodes = self.client.work.episodes
+        assert not before_episodes
+        diff = self.client.fetch_remote_episodes()
+
+        assert diff.appended
+
+        after_episodes = self.client.work.episodes
+        assert after_episodes
+
+        remote_episodes = self.client.get_remote_episodes()
+
+        assert {episode.id for episode in remote_episodes} == {episode.id for episode in after_episodes}

--- a/tests/helper/__init__.py
+++ b/tests/helper/__init__.py
@@ -1,11 +1,11 @@
 """helper module for test cases"""
-from .classes import EpisodeExistsTest, NoEpisodesTest, Test, WorkTOMLNotExistsTest
+from .classes import EpisodeExistsTest, NoEpisodeTest, Test, WorkTOMLNotExistsTest
 from .functions import Case, createClient, logger, set_color
 
 __all__ = [
     "Case",
     "EpisodeExistsTest",
-    "NoEpisodesTest",
+    "NoEpisodeTest",
     "Test",
     "WorkTOMLNotExistsTest",
     "createClient",

--- a/tests/helper/classes.py
+++ b/tests/helper/classes.py
@@ -59,7 +59,7 @@ class WorkTOMLNotExistsTest(Test):
         self.client.config_dir.work_toml.unlink(missing_ok=True)
 
 
-class NoEpisodesTest(Test):
+class NoEpisodeTest(Test):
     """エピソードが存在しない場合のテスト"""
 
     client: Client


### PR DESCRIPTION
impl `kakuyomu episode fetch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - エピソードのフェッチ機能が追加され、リモートのエピソードを取得できるようになりました。
  - エピソードの比較とクエリ機能が導入され、IDに基づいてエピソードを検索し比較することが可能になりました。

- **バグ修正**
  - ログレベルが`DEBUG`から`WARN`に調整され、不要な情報の表示が減少しました。

- **ドキュメント**
  - ログとテスト関連のクラス名が更新され、文書の明確性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->